### PR TITLE
Update docker-compose-router.yml to reflect tag

### DIFF
--- a/docker-compose-router.yml
+++ b/docker-compose-router.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   zerotier:
-    image: "zyclonite/zerotier:router"
+    image: "zyclonite/zerotier:router-main"
     container_name: zerotier-one
     devices:
       - /dev/net/tun


### PR DESCRIPTION
No docker image with tag
zyclonite/zerotier:router

exists. Therefore docker compose cannot pull the image. zyclonite/zerotier:router-main is the closest match.