### PR TITLE
unexpected script termination - entrypoint-router.sh

### DIFF
--- a/scripts/entrypoint-router.sh
+++ b/scripts/entrypoint-router.sh
@@ -99,7 +99,8 @@ update_iptables() {
 update_iptables "A" "adding"
 
 # define where the ZeroTier daemon will write its output (if any)
-TAIL_PIPE=$(mktemp /tmp/zerotier-ipc-XXXXXX)
+TAIL_PIPE="/tmp/zerotier-ipc-log"
+cat /dev/null >"${TAIL_PIPE}"
 
 # start listening and echoing anything that appears there into this process
 tail -f "${TAIL_PIPE}" &
@@ -125,19 +126,11 @@ termination_handler() {
 	update_iptables "D" "removing"
 
 	# relay the termination message to the daemon
+	# (the pipe listener is cleaned up automatically)
 	if [ -d "/proc/${ZEROTIER_DAEMON_PID}" ] ; then
 		kill -TERM ${ZEROTIER_DAEMON_PID}
 		wait ${ZEROTIER_DAEMON_PID}
 	fi
-
-	# tell the pipe listener to go away too
-	if [ -d "/proc/${TAIL_PIPE_PID}" ] ; then
-		kill -TERM ${TAIL_PIPE_PID}
-		wait ${TAIL_PIPE_PID}
-	fi
-
-	# clean up the pipe file
-	rm "${TAIL_PIPE}"
 
 }
 


### PR DESCRIPTION
Resolves issue raised in #15 where `entrypoint-router.sh` exits after
telling the pipe listener process to go away, with the result that the
temporary pipe file does not get cleaned up on a container restart.

> The temporary pipe file is not persisted so it will always get cleaned
 up when the container is terminated or recreated.

The pipe listener process exits automatically without needing any signal
from `entrypoint-router.sh` so the script lines doing that are removed.

Instead of creating the pipe file using `mktemp` with a random suffix,
the hard-coded name "/tmp/zerotier-ipc-log" will be used. The pipe file
is:

* still in `/tmp` so it is not persisted and will get cleaned up when
 the container is terminated.

* always initalised empty each time the script runs (important if the
 container restarts).

Fixes: #15

Signed-off-by: Phill Kelley <34226495+Paraphraser@users.noreply.github.com>