### PR TITLE
Fix a small typo.

### DIFF
--- a/README-router.md
+++ b/README-router.md
@@ -16,7 +16,7 @@ Technically, this could be described as a *half-router*:
 ``` console
 $ docker run --name zerotier-one --device=/dev/net/tun \
   --cap-add=NET_ADMIN --cap-add=NET_RAW --cap-add=SYS_ADMIN \
-  --env TZ=Etc/UTC --env PUID=999 -env PGID=994 \
+  --env TZ=Etc/UTC --env PUID=999 --env PGID=994 \
   --env ZEROTIER_ONE_LOCAL_PHYS=eth0 \
   --env ZEROTIER_ONE_USE_IPTABLES_NFT=false \
   --env ZEROTIER_ONE_GATEWAY_MODE=inbound \


### PR DESCRIPTION
A missing dash in the command that's hard to spot can valuable few minutes. Gives the following error:

![image](https://user-images.githubusercontent.com/6062311/196547586-dd79cdbc-06e8-47f3-88e5-6bb4bf946de3.png)
